### PR TITLE
Fix cmake warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+main
+hoge.cpp
+a.out
+
+spqlios/build

--- a/spqlios/CMakeLists.txt
+++ b/spqlios/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
+project(spqlios)
 
 # This is the nayuki fft processor for the tfhe library
 enable_language(ASM)


### PR DESCRIPTION
* Ignore `main`, `a.out`, `hoge.cpp` and `spqlios/build` from this repository. 
* Fix the following warning from CMake.
```
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.

```